### PR TITLE
Return boolean & prefix for prefixed properties

### DIFF
--- a/feature.js
+++ b/feature.js
@@ -79,20 +79,32 @@
   var Feature = {
     // Test if CSS 3D transforms are supported
     css3Dtransform : (function() {
-      var test = (!util.old && util.pfx("perspective") !== null);
-      return !!test;
+      var test = !!(!util.old && util.pfx("perspective") !== null);
+      var prop = util.pfx("transform");
+      return {
+        support: test,
+        property: test ? prop : null
+      };
     })(),
 
     // Test if CSS transforms are supported
     cssTransform : (function() {
-      var test = (!util.old && util.pfx("transformOrigin") !== null);
-      return !!test;
+      var test = !!(!util.old && util.pfx("transformOrigin") !== null);
+      var prop = util.pfx("transform");
+      return {
+        support: test,
+        property: test ? prop : null
+      };
     })(),
 
     // Test if CSS transitions are supported
     cssTransition : (function() {
-      var test = util.pfx("transition") !== null;
-      return !!test;
+      var prop = util.pfx("transition");
+      var test = !!(prop !== null);
+      return {
+        support: test,
+        property: test ? prop : null
+      };
     })(),
 
     // Test if addEventListener is supported


### PR DESCRIPTION
`3Dtransforms`, `transforms`, and `transitions` are fetching the vendor-prefixed value anyway... might as well tell the end-user what Feature.js found.

With this change, those 3 features will return an Object of
```js
{
  support: Boolean, 
  property: String || null
}
```

For the sake of brevity / bytes, these keys could be renamed to `use` and `prop`.