### PR TITLE
Allow Extensions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,3 @@
 node_modules
+yarn.lock
+yarn-error.log

--- a/Gulpfile.js
+++ b/Gulpfile.js
@@ -3,12 +3,16 @@ var uglify = require('gulp-uglify');
 var jshint = require('gulp-jshint');
 var rename = require('gulp-rename');
 var insert = require('gulp-insert');
+var jest   = require('gulp-jest').default;
 
 var pjson = require('./package.json');
 
-gulp.task('build', function () {
+gulp.task('test', function () {
+    return gulp.src('./').pipe(jest());
+});
+
+gulp.task('build', ['test'], function () {
   return gulp.src(['./feature.js'])
-  
     .pipe(jshint())
     .pipe(jshint.reporter('default'))
     .pipe(uglify('feature.min.js'))

--- a/README.md
+++ b/README.md
@@ -136,7 +136,11 @@ To build feature.min.js run the following command:
 $ gulp build
 ```
 
+To run the tests, which are also run during the build task, use:
 
+```shell
+$ npm run test
+```
 
 ## Tested on the following platforms
 

--- a/README.md
+++ b/README.md
@@ -71,6 +71,8 @@ There are few gotchas related to browser feature detection in general and these 
 
 ## API reference
 
+### Tests
+
 Below you’ll find a list of all the available browser feature tests and how to call them.
 
 ```javascript
@@ -103,6 +105,63 @@ feature.viewportUnit
 feature.webGL
 ```
 
+### CSS Feature Hooks
+
+By running:
+
+```javascript
+feature.testAll()
+```
+
+each aforementioned test will be run and its result will be added to the class names on the root `html` element on the page:
+
+```html
+<html class=" js css3dtransform csstransform csstransition addeventlistener queryselectorall matchmedia devicemotion deviceorientation contextmenu classlist placeholder localstorage historyapi viewportunit remunit canvas svg webgl cors async defer geolocation srcset sizes pictureelement" lang="en">
+```
+
+### Extending
+
+You can also extend the library through:
+
+```javascript
+feature.extend(NAME, CALLBACK);
+```
+
+This way you can add your own tests to the library, the result of which will also be integrated with the `testAll()` method. Here's a contrived example:
+
+```html
+<script src="path/to/feature.js"></script>
+
+<script>
+  feature.extend('foo', function () {
+    return true;
+  });
+
+  feature.testAll();
+</script>
+```
+
+This would add the `foo` class name to the `html` document element as well.
+
+Use this to write your own tests, customize existing tests, or as a stop-gap measure to fix a bug in a test between releases of the library. Please share the love, if you find yourself in the latter example, by [submitting an issue](https://github.com/viljamis/feature.js/issues) for us to fix in an upcoming release.
+
+#### Utilities
+
+`feature.extend` will graciously expose the utility methods to your callback. These utilities are used internally within the library and will help unify your added tests:
+
+```javascript
+feature.extend('foo', function (util) {
+  // Simple create element method
+  util.create('image'); // returns HTMLElement
+
+  // Test if it's an old device that we want to filter out
+  util.old; // returns Boolean
+
+  // Function that takes a standard CSS property name as a parameter and returns
+  // its prefixed version valid for the current browser it runs in
+  util.pfx('transition'); // Returns falsey if unsupported, truthy if supported
+});
+```
 
 
 ## Live demo

--- a/feature.js
+++ b/feature.js
@@ -212,11 +212,20 @@
     testAll : function() {
       var classes = " js";
       for (var test in this) {
-        if (test !== "testAll" && this[test]) {
+        if (test !== "testAll" && test !== 'extend' && this[test]) {
           classes += " " + test;
         }
       }
       docEl.className += classes.toLowerCase();
+    },
+
+    extend : function(name, callback) {
+      if (typeof callback !== 'function') {
+        throw new TypeError('Feature.extend: `callback` is not a Function');
+      }
+
+      this[name] = !!callback(util);
+      return this;
     }
 
   };

--- a/feature.js
+++ b/feature.js
@@ -21,7 +21,15 @@
  */
 
 /* globals DocumentTouch */
-;(function (window, document, undefined) {
+;(function (root, document, factory) {
+  if (typeof define === 'function' && define.amd) {
+    // AMD. Register as an anonymous module.
+    define([], factory);
+  } else {
+    // Browser globals (root is window)
+    root.feature = factory();
+  }
+}(typeof self !== 'undefined' ? self : this, document, function () {
   "use strict";
 
   // For minification only
@@ -216,6 +224,6 @@
   /**
    * Expose a public-facing API
    */
-  window.feature = Feature;
+  return Feature;
 
-}(window, document));
+}));

--- a/feature.js
+++ b/feature.js
@@ -212,7 +212,7 @@
     testAll : function() {
       var classes = " js";
       for (var test in this) {
-        if (test !== "testAll" && test !== "constructor" && this[test]) {
+        if (test !== "testAll" && this[test]) {
           classes += " " + test;
         }
       }

--- a/feature.test.js
+++ b/feature.test.js
@@ -1,0 +1,25 @@
+require('./feature');
+
+describe('.testAll()', () => {
+  beforeAll(() => {
+    window.feature.testAll();
+  });
+
+  test('test classnames are added to documentElement', () => {
+    const classes = document.documentElement.className;
+
+    expect(classes.includes('js')).toBe(true);
+
+    for (var test in window.feature) {
+      if (test === 'testAll') { continue; }
+
+      if (['testAll'].includes(test)) {
+        expect(classes).not.toMatch(new RegExp(test, 'i'));
+      } else if (window.feature[test]) {
+        expect(classes).toMatch(new RegExp(test, 'i'));
+      } else {
+        expect(classes).not.toMatch(new RegExp(test, 'i'));
+      }
+    }
+  });
+});

--- a/feature.test.js
+++ b/feature.test.js
@@ -13,7 +13,7 @@ describe('.testAll()', () => {
     for (var test in window.feature) {
       if (test === 'testAll') { continue; }
 
-      if (['testAll'].includes(test)) {
+      if (['testAll', 'extend'].includes(test)) {
         expect(classes).not.toMatch(new RegExp(test, 'i'));
       } else if (window.feature[test]) {
         expect(classes).toMatch(new RegExp(test, 'i'));
@@ -21,5 +21,72 @@ describe('.testAll()', () => {
         expect(classes).not.toMatch(new RegExp(test, 'i'));
       }
     }
+  });
+});
+
+describe('.extend()', () => {
+  test('additional feature tests can be added', () => {
+    window.feature.extend('foo', function () {
+      return true;
+    });
+
+    window.feature.extend('bar', function () {
+      return false;
+    });
+
+    window.feature.extend('baz', function () {
+      return 'not a boolean';
+    });
+
+    window.feature.extend('qux', function () {});
+
+    expect(window.feature.foo).toBe(true);
+    expect(window.feature.bar).toBe(false);
+    expect(window.feature.baz).toBe(true);
+    expect(window.feature.qux).toBe(false);
+
+    expect(() => window.feature.extend('corge')).toThrow(TypeError);
+    expect(() => window.feature.extend('corge')).toThrow('not a Function');
+
+    window.feature.testAll();
+
+    expect(document.documentElement.className.includes('foo')).toBe(true);
+    expect(document.documentElement.className.includes('bar')).toBe(false);
+  });
+
+  test('utilities are supplied to callback', () => {
+    window.feature.extend('foo', function (util) {
+      expect(util).toHaveProperty('create');
+      expect(util).toHaveProperty('old');
+      expect(util).toHaveProperty('pfx');
+
+      expect(util.create('foo')).toBeInstanceOf(HTMLElement);
+
+      expect(util.old).toBe(false);
+
+      expect(util.pfx).toBeInstanceOf(Function);
+      expect(util.pfx('bar')).toBeNull();
+      expect(util.pfx('min-height')).toMatch(/min-height/);
+    });
+  });
+
+  test('tests can be overridden', () => {
+    // known to be true, thanks to `jest-canvas-mock` package
+    expect(window.feature.canvas).toBe(true);
+
+    window.feature.extend('canvas', function () {
+      return false;
+    });
+
+    expect(window.feature.canvas).toBe(false);
+  });
+
+  test('returns an instance', function () {
+    const extension = window.feature.extend('foo', function () {
+      return true;
+    });
+
+    expect(window.feature).toStrictEqual(extension);
+    expect(window.feature.foo).toBeDefined();
   });
 });

--- a/jest.config.js
+++ b/jest.config.js
@@ -1,0 +1,6 @@
+module.exports = {
+  browser: true,
+  setupFiles: [
+    'jest-canvas-mock'
+  ]
+};

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "test": "tests"
   },
   "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1"
+    "test": "jest"
   },
   "repository": {
     "type": "git",
@@ -22,9 +22,13 @@
   "devDependencies": {
     "gulp": "^3.9.0",
     "gulp-insert": "^0.5.0",
+    "gulp-jest": "^4.0.2",
     "gulp-jshint": "^2.0.0",
     "gulp-rename": "^1.2.2",
     "gulp-uglify": "^1.5.1",
+    "jest": "^24.8.0",
+    "jest-canvas-mock": "^2.1.0",
+    "jest-cli": "^24.8.0",
     "jshint": "^2.9.1"
   }
 }


### PR DESCRIPTION
I wanted to float this feature to see how it was received, as it would solve a few problems we've been facing using this library on our platform. The original idea was to add an extension API, which made me realize I should test it, which lead me to setup Jest, which required me to create a UMD wrapper for the library.

I created a `1.1.0` milestone, since this should probably go out in a minor.