### PR TITLE
Fix possible bug with localStorage test

### DIFF
--- a/feature.js
+++ b/feature.js
@@ -121,7 +121,7 @@
 
     // Test if localStorage is supported
     localStorage : (function() {
-      var test = "x";
+      var test = "featurejs-test";
       try {
         localStorage.setItem(test, test);
         localStorage.removeItem(test);


### PR DESCRIPTION
This changes the key used for the localStorage test from `x` to the
namespaced `featurejs-test` for better collision avoidance.

Resolves #25