### PR TITLE
Rewrite localStorage Test

### DIFF
--- a/feature.js
+++ b/feature.js
@@ -126,11 +126,18 @@
 
     // Test if localStorage is supported
     localStorage: (function() {
-      var test = 'featurejs-test';
+      var test;
+
+      if ('localStorage' in window === false) {
+        return false;
+      }
+
       try {
-        localStorage.setItem(test, test);
-        localStorage.removeItem(test);
-        return true;
+        window.localStorage.setItem('featurejs-test', 'foobar');
+        test = window.localStorage.getItem('featurejs-test');
+        window.localStorage.removeItem('featurejs-test');
+
+        return !!test;
       } catch (err) {
         return false;
       }


### PR DESCRIPTION
Testing for the presence of `localStorage` on window (as per #21) before
trying to set an item is preferable. The test was rewritten to test the
return value of `localStorage.getItem` rather than `setItem` since we
should be making sure we are getting the values back correctly.

Resolves #21