### PR TITLE
Fix LocalStorage test

### DIFF
--- a/feature.js
+++ b/feature.js
@@ -137,21 +137,15 @@
 
     // Test if localStorage is supported
     localStorage: (function() {
-      var test;
-
-      if ('localStorage' in window) {
-        try {
-          window.localStorage.setItem('featurejs-test', 'foobar');
-          test = window.localStorage.getItem('featurejs-test');
-          window.localStorage.removeItem('featurejs-test');
-        } catch (err) {
-          // no content in the cache means it couldn't be added to at all (old
-          // Safari) otherwise we just went over a non-zero quota
-          return !!window.localStorage.length;
-        }
+      try {
+        window.localStorage.setItem('featurejs-test', 'foobar');
+        window.localStorage.removeItem('featurejs-test');
+        return true;
+      } catch (err) {
+        // no content in the cache means it couldn't be added to at all (old
+        // Safari) otherwise we just went over a non-zero quota
+        return !!window.localStorage.length;
       }
-
-      return !!test;
     })(),
 
     // Test if History API is supported


### PR DESCRIPTION
@JohannesAnd reported that we receive an `Access is denied for this
document` error when users have blocked cookies and data in Chrome.
Checking Modernizr's implementation I've found that this happens in a
few other browsers as well.

Closes #67