### PR TITLE
Remove ancient browser support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+# v2.0.0 (2021-09-20)
+
+- Remove old browser checks for Android 1 + 2, Silk 1
+- Remove navigation.userAgent deprecation warning
+
 # v1.1.3 (2021-06-15)
 
 - Adds test for “Fetch”.

--- a/README.md
+++ b/README.md
@@ -4,7 +4,9 @@ Feature.js is a fast, simple and lightweight browser feature detection library. 
 
 With [Feature.js](http://featurejs.com/), it’s simple to build progressively enhanced experiences that use feature detection to determine if a code can be executed in the user’s browser.
 
+# Version Note
 
+`v1.x` makes considerations for very early Android & Amazon Silk browsers whereas `v2.x` drops this support.
 
 ## How to use
 

--- a/feature.js
+++ b/feature.js
@@ -53,11 +53,6 @@
     },
 
     /**
-     * Test if it's an old device that we want to filter out
-     */
-    old: !!(/(Android\s(1\.|2\.))|(Silk\/1\.)/i.test(nav.userAgent)),
-
-    /**
      * Function that takes a standard CSS property name as a parameter and
      * returns it's prefixed version valid for current browser it runs in
      */
@@ -95,13 +90,13 @@
   var Feature = {
     // Test if CSS 3D transforms are supported
     css3Dtransform: (function() {
-      var test = (!util.old && util.pfx('perspective') !== null);
+      var test = (util.pfx('perspective') !== null);
       return !!test;
     })(),
 
     // Test if CSS transforms are supported
     cssTransform: (function() {
-      var test = (!util.old && util.pfx('transformOrigin') !== null);
+      var test = (util.pfx('transformOrigin') !== null);
       return !!test;
     })(),
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "feature.js",
-  "version": "1.1.3",
+  "version": "2.0.0",
   "description": "Feature.js is a fast, simple and lightweight browser feature detection library in 1kb.",
   "main": "feature.js",
   "directories": {


### PR DESCRIPTION
Removes support for browsers that are presumably too old to be worth (not) supporting.

This was the simplest solution to close #81 and it also would close #50.

Totally happy not to take the lazy way out if we have a good argument for keeping support up.